### PR TITLE
fix: warning security buffer deprecated

### DIFF
--- a/utils/base64.js
+++ b/utils/base64.js
@@ -1,14 +1,14 @@
 function encode(input) {
-    const buff = new Buffer(input, 'utf8')
+    const buff = new Buffer.from(input, 'utf8')
     return buff.toString('base64')
 }
 
 function decode(input) {
-    const buff = new Buffer(input, 'base64')
+    const buff = new Buffer.from(input, 'base64')
     return buff.toString('utf8')
 }
 
 module.exports = {
-    encode, 
+    encode,
     decode
 }


### PR DESCRIPTION
## Info 

Use `Buffer.from` instead of `Buffer`